### PR TITLE
WinコマンドをUTF-8の状態で実行する

### DIFF
--- a/common/executor.go
+++ b/common/executor.go
@@ -1,0 +1,9 @@
+package common
+
+func ExecuteWinCmd(cmd string) {
+	out, err := exec.Command("cmd.exe", "/k", "chcp 65001 && "+cmd).Output()
+    if err != nil {
+        return nil, err
+	}
+	return out
+}


### PR DESCRIPTION
`cmd /K`で`chcp`を渡して実行文字コードの指定を行える仕様に変更